### PR TITLE
Port deleted in room gateway

### DIFF
--- a/src/room/room.gateway.ts
+++ b/src/room/room.gateway.ts
@@ -93,7 +93,7 @@ interface CodeEditPayload {
   newCode: string;
 }
 
-@WebSocketGateway(3000, {
+@WebSocketGateway({
   cors: {
     origin: '*',
     methods: ['GET', 'POST'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated WebSocket gateway configuration to rely on default or externally assigned ports instead of a fixed port number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->