### PR TITLE
Fix: preserve room settings when changing language

### DIFF
--- a/src/room/room.gateway.ts
+++ b/src/room/room.gateway.ts
@@ -274,6 +274,9 @@ export class RoomGateway implements OnGatewayConnection, OnGatewayDisconnect {
     }
     if (room.completed) return;
 
+    // Получаем текущую активную комнату для сохранения настроек
+    const activeRoom = this.activeRooms.find((r) => r.id === room.id);
+
     const updatedRoom = await this.roomService.editRoom(room.id, {
       studentCursorEnabled: data.studentCursorEnabled,
       studentEditCodeEnabled: data.studentEditCodeEnabled,
@@ -283,17 +286,24 @@ export class RoomGateway implements OnGatewayConnection, OnGatewayDisconnect {
       taskId: data.taskId,
     });
 
-    this.activeRooms = this.activeRooms.map((activeRoom) => {
-      if (activeRoom.id === updatedRoom.id) {
+    this.activeRooms = this.activeRooms.map((activeRoomItem) => {
+      if (activeRoomItem.id === updatedRoom.id) {
         return {
-          ...activeRoom,
-          studentCursorEnabled: Boolean(data.studentCursorEnabled),
-          studentEditCodeEnabled: Boolean(data.studentEditCodeEnabled),
-          studentSelectionEnabled: Boolean(data.studentSelectionEnabled),
+          ...activeRoomItem,
+          // Используем переданные значения или сохраняем текущие из activeRoom или room
+          studentCursorEnabled: data.studentCursorEnabled !== undefined 
+            ? Boolean(data.studentCursorEnabled)
+            : (activeRoom?.studentCursorEnabled ?? room.studentCursorEnabled),
+          studentEditCodeEnabled: data.studentEditCodeEnabled !== undefined 
+            ? Boolean(data.studentEditCodeEnabled)
+            : (activeRoom?.studentEditCodeEnabled ?? room.studentEditCodeEnabled),
+          studentSelectionEnabled: data.studentSelectionEnabled !== undefined 
+            ? Boolean(data.studentSelectionEnabled)
+            : (activeRoom?.studentSelectionEnabled ?? room.studentSelectionEnabled),
         };
       }
 
-      return activeRoom;
+      return activeRoomItem;
     });
 
     this.server

--- a/src/room/room.service.ts
+++ b/src/room/room.service.ts
@@ -28,14 +28,28 @@ export class RoomService {
 
   async editRoom(id: string, dto: EditRoomDto): Promise<RoomRdo> {
     try {
+      const currentRoom = await this.prisma.room.findUnique({
+        where: { id, teacher: dto.telegramId },
+      });
+
+      if (!currentRoom) {
+        throw new NotFoundException('Room not found');
+      }
+
       const editedRoom = await this.prisma.room.update({
         where: { id, teacher: dto.telegramId },
         data: {
-          taskId: dto.taskId,
-          language: dto.language,
-          studentCursorEnabled: dto.studentCursorEnabled,
-          studentSelectionEnabled: dto.studentSelectionEnabled,
-          studentEditCodeEnabled: dto.studentEditCodeEnabled,
+          ...(dto.taskId !== undefined && { taskId: dto.taskId }),
+          ...(dto.language !== undefined && { language: dto.language }),
+          studentCursorEnabled: dto.studentCursorEnabled !== undefined 
+            ? dto.studentCursorEnabled 
+            : currentRoom.studentCursorEnabled,
+          studentSelectionEnabled: dto.studentSelectionEnabled !== undefined 
+            ? dto.studentSelectionEnabled 
+            : currentRoom.studentSelectionEnabled,
+          studentEditCodeEnabled: dto.studentEditCodeEnabled !== undefined 
+            ? dto.studentEditCodeEnabled 
+            : currentRoom.studentEditCodeEnabled,
         }
       });
 


### PR DESCRIPTION
- Preserve studentCursorEnabled, studentSelectionEnabled, studentEditCodeEnabled settings when only language is changed
- Fix issue where settings were reset to false when language was updated
- Update room.service.ts to keep current settings if not provided in DTO
- Update room.gateway.ts to maintain settings in activeRooms when not explicitly changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved room editing validation to verify ownership and existence before applying changes
  * Fixed settings preservation during room edits—existing room settings are now retained when not explicitly modified
  * Enhanced error handling for invalid room edit operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->